### PR TITLE
Add liquid glass themed bubble catching mini-game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,542 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>GitHub Pages Test</title>
+  <title>液体玻璃泡泡捕手</title>
+  <style>
+    :root {
+      color-scheme: dark light;
+      --glass-bg: rgba(255, 255, 255, 0.14);
+      --glass-border: rgba(255, 255, 255, 0.28);
+      --glass-highlight: rgba(255, 255, 255, 0.7);
+      --text-main: #f5f7ff;
+      --accent: 210 100% 70%;
+      --shadow-color: rgba(15, 30, 50, 0.45);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Poppins", "Segoe UI", "PingFang SC", "Microsoft Yahei", sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--text-main);
+      background: radial-gradient(circle at 20% 20%, rgba(100, 180, 255, 0.35), transparent 50%),
+        radial-gradient(circle at 80% 0%, rgba(255, 120, 180, 0.45), transparent 45%),
+        linear-gradient(135deg, #0c1a2a, #08111d 55%, #091936);
+      overflow: hidden;
+    }
+
+    body::before {
+      content: "";
+      position: absolute;
+      inset: -25vmax;
+      background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.04), transparent 45%),
+        radial-gradient(circle at 65% 75%, rgba(255, 255, 255, 0.05), transparent 60%);
+      filter: blur(30px);
+      z-index: -2;
+    }
+
+    .floating-shapes span {
+      position: absolute;
+      width: clamp(180px, 24vw, 280px);
+      aspect-ratio: 1 / 1;
+      border-radius: 55% 45% 60% 40% / 60% 40% 60% 40%;
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(80, 200, 255, 0.05));
+      box-shadow: inset 0 0 40px rgba(255, 255, 255, 0.3);
+      filter: blur(0.5px);
+      animation: drip 18s ease-in-out infinite;
+      opacity: 0.32;
+      z-index: -1;
+    }
+
+    .floating-shapes span:nth-child(1) {
+      top: 10vh;
+      left: 10vw;
+      animation-delay: -6s;
+    }
+
+    .floating-shapes span:nth-child(2) {
+      bottom: 8vh;
+      right: 12vw;
+      animation-delay: -12s;
+    }
+
+    .floating-shapes span:nth-child(3) {
+      top: 55vh;
+      left: 25vw;
+      animation-delay: -3s;
+    }
+
+    @keyframes drip {
+      0%, 100% {
+        transform: translate3d(0, 0, 0) scale(1.05);
+      }
+      35% {
+        transform: translate3d(12px, -14px, 0) scale(0.95) rotate(2deg);
+      }
+      70% {
+        transform: translate3d(-16px, 18px, 0) scale(1.02) rotate(-1.5deg);
+      }
+    }
+
+    main {
+      width: min(960px, 92vw);
+      display: grid;
+      gap: clamp(24px, 4vw, 40px);
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      align-items: stretch;
+      position: relative;
+      z-index: 1;
+    }
+
+    .glass-panel {
+      background: var(--glass-bg);
+      backdrop-filter: blur(26px) saturate(120%);
+      -webkit-backdrop-filter: blur(26px) saturate(120%);
+      border-radius: 28px;
+      border: 1px solid var(--glass-border);
+      box-shadow: 0 20px 45px var(--shadow-color);
+      padding: clamp(20px, 3vw, 32px);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .glass-panel::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 45%);
+      opacity: 0.5;
+      pointer-events: none;
+    }
+
+    .intro h1 {
+      font-size: clamp(2rem, 4vw, 3rem);
+      margin: 0 0 12px;
+      letter-spacing: 0.02em;
+    }
+
+    .intro p {
+      margin: 0;
+      line-height: 1.65;
+    }
+
+    .scoreboard {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 20px;
+    }
+
+    .stat {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 12px 14px;
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(255, 255, 255, 0.22);
+      min-width: 90px;
+      text-align: center;
+      box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.15);
+    }
+
+    .stat span:first-child {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      opacity: 0.76;
+    }
+
+    .stat strong {
+      font-size: 1.6rem;
+    }
+
+    button {
+      font: inherit;
+      color: inherit;
+      border: none;
+      cursor: pointer;
+      background: transparent;
+    }
+
+    .primary-button {
+      padding: 12px 24px;
+      border-radius: 999px;
+      background: linear-gradient(135deg, hsla(var(--accent) / 0.85), hsla(calc(var(--accent) + 60) / 0.65));
+      color: #08111d;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      border: 1px solid rgba(255, 255, 255, 0.42);
+      box-shadow: 0 12px 25px rgba(35, 60, 90, 0.45);
+      transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+    }
+
+    .primary-button:is(:hover, :focus-visible) {
+      transform: translateY(-1px) scale(1.015);
+      box-shadow: 0 14px 30px rgba(35, 60, 90, 0.55);
+      filter: saturate(1.2);
+    }
+
+    .primary-button:disabled {
+      cursor: wait;
+      filter: saturate(0.7);
+      opacity: 0.75;
+    }
+
+    .game-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      height: 100%;
+    }
+
+    .timer-bar {
+      width: 100%;
+      height: 8px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      overflow: hidden;
+      position: relative;
+    }
+
+    .timer-fill {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      transform-origin: left;
+      background: linear-gradient(120deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+      box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.45);
+      transition: transform 0.25s ease;
+    }
+
+    .game-area {
+      position: relative;
+      flex: 1;
+      border-radius: 26px;
+      padding: 16px;
+      background: rgba(12, 22, 36, 0.3);
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      overflow: hidden;
+      min-height: clamp(320px, 50vh, 420px);
+      box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.25);
+    }
+
+    .game-area::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.16), transparent 55%);
+      pointer-events: none;
+    }
+
+    .idle-hint {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      text-align: center;
+      padding: 0 24px;
+      font-size: 1.05rem;
+      line-height: 1.6;
+      color: rgba(255, 255, 255, 0.8);
+    }
+
+    .bubble {
+      position: absolute;
+      border-radius: 50%;
+      border: 1px solid rgba(255, 255, 255, 0.6);
+      background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.05) 55%),
+        conic-gradient(from 140deg at 50% 50%, hsla(var(--hue, 210) 100% 75% / 0.75), hsla(calc(var(--hue, 210) + 80) 100% 65% / 0.55), hsla(calc(var(--hue, 210) + 140) 90% 70% / 0.4), hsla(var(--hue, 210) 100% 75% / 0.75));
+      box-shadow: inset 0 0 22px rgba(255, 255, 255, 0.7), 0 12px 35px rgba(7, 10, 25, 0.55);
+      cursor: pointer;
+      transition: transform 0.25s ease, opacity 0.25s ease;
+    }
+
+    .bubble::after {
+      content: "";
+      position: absolute;
+      inset: 12%;
+      border-radius: 50%;
+      background: radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.9), transparent 55%);
+      opacity: 0.9;
+    }
+
+    .bubble:focus-visible {
+      outline: 2px dashed rgba(255, 255, 255, 0.8);
+      outline-offset: 4px;
+    }
+
+    .bubble.pop {
+      animation: pop 0.22s ease forwards;
+    }
+
+    .bubble.fade {
+      opacity: 0;
+      transform: scale(0.9);
+    }
+
+    @keyframes pop {
+      0% {
+        transform: scale(1) translateZ(0);
+        opacity: 1;
+      }
+      70% {
+        transform: scale(1.35) translateZ(0);
+        opacity: 0.95;
+      }
+      100% {
+        transform: scale(0.4) translateZ(0);
+        opacity: 0;
+      }
+    }
+
+    .status-text {
+      font-size: 0.95rem;
+      color: rgba(255, 255, 255, 0.85);
+      min-height: 1.4em;
+    }
+
+    @media (max-width: 720px) {
+      body {
+        padding: 40px 0;
+      }
+
+      main {
+        grid-template-columns: 1fr;
+      }
+
+      .game-area {
+        min-height: clamp(360px, 55vh, 460px);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+  </style>
 </head>
 <body>
-  <h1>🚀 Hello GitHub Pages!</h1>
-  <p>If you see this page, GitHub Pages is working correctly.</p>
+  <div class="floating-shapes" aria-hidden="true">
+    <span></span>
+    <span></span>
+    <span></span>
+  </div>
+  <main>
+    <section class="glass-panel intro">
+      <h1>液体玻璃泡泡捕手 🎮</h1>
+      <p>欢迎来到未来感十足的液体玻璃乐园！<br>点击在玻璃面板中闪现的能量泡泡，三十秒内尽可能多地捕捉它们，刷新你的个人纪录。</p>
+    </section>
+    <section class="glass-panel game-wrapper" aria-live="polite">
+      <div class="scoreboard">
+        <div class="stat">
+          <span>得分</span>
+          <strong id="score">0</strong>
+        </div>
+        <div class="stat">
+          <span>时间</span>
+          <strong><span id="time">30</span>s</strong>
+        </div>
+        <div class="stat">
+          <span>最佳</span>
+          <strong id="bestScore">0</strong>
+        </div>
+        <button id="startButton" class="primary-button" type="button">开始游戏</button>
+      </div>
+      <div class="timer-bar" role="progressbar" aria-valuemin="0" aria-valuemax="30" aria-valuenow="30">
+        <div class="timer-fill" id="timerFill"></div>
+      </div>
+      <p class="status-text" id="statusText">准备好了吗？点击“开始游戏”，让泡泡在玻璃宇宙中舞动！</p>
+      <div class="game-area" id="gameArea">
+        <div class="idle-hint" id="idleHint">在有限的时间里捕捉越多泡泡，你的玻璃能量就越充沛。保持专注，随时准备点击！</div>
+      </div>
+    </section>
+  </main>
+  <script>
+    (() => {
+      const GAME_DURATION = 30;
+      const startButton = document.getElementById('startButton');
+      const scoreElement = document.getElementById('score');
+      const timeElement = document.getElementById('time');
+      const bestScoreElement = document.getElementById('bestScore');
+      const timerFill = document.getElementById('timerFill');
+      const timerBar = document.querySelector('.timer-bar');
+      const statusText = document.getElementById('statusText');
+      const gameArea = document.getElementById('gameArea');
+      const idleHint = document.getElementById('idleHint');
+
+      let bestScore = Number(localStorage.getItem('liquid-glass-best-score') || '0');
+      let isPlaying = false;
+      let score = 0;
+      let timeLeft = GAME_DURATION;
+      let timerInterval = null;
+      let spawnTimeout = null;
+      let bubbleTimeout = null;
+      let activeBubble = null;
+      let lastHitTime = 0;
+      let streak = 0;
+
+      bestScoreElement.textContent = bestScore;
+      updateTimerDisplay();
+
+      startButton.addEventListener('click', startGame);
+
+      function startGame() {
+        if (isPlaying) return;
+        isPlaying = true;
+        score = 0;
+        timeLeft = GAME_DURATION;
+        streak = 0;
+        lastHitTime = 0;
+        updateScore();
+        updateTimerDisplay();
+        statusText.textContent = '玻璃能量正在凝聚，快点击泡泡收集能量！';
+        idleHint.style.display = 'none';
+        clearExistingBubble();
+        clearTimeout(spawnTimeout);
+        startButton.disabled = true;
+        startButton.textContent = '游戏中...';
+
+        timerInterval = setInterval(() => {
+          timeLeft -= 1;
+          if (timeLeft <= 0) {
+            timeLeft = 0;
+            updateTimerDisplay();
+            endGame();
+            return;
+          }
+          updateTimerDisplay();
+        }, 1000);
+
+        spawnBubble();
+      }
+
+      function endGame() {
+        isPlaying = false;
+        startButton.disabled = false;
+        startButton.textContent = '再来一局';
+        clearInterval(timerInterval);
+        clearTimeout(spawnTimeout);
+        clearExistingBubble();
+
+        const message = score > 0
+          ? `最终得分 ${score}！${streak > 2 ? '连击火热，玻璃能量爆棚！' : '再接再厉，冲击更高纪录！'}`
+          : '这次没捕到泡泡，再来试一次吧！';
+        statusText.textContent = message;
+        idleHint.style.display = '';
+
+        if (score > bestScore) {
+          bestScore = score;
+          localStorage.setItem('liquid-glass-best-score', String(bestScore));
+          bestScoreElement.textContent = bestScore;
+          statusText.textContent = `新纪录！你捕获了 ${score} 个泡泡！`;
+        }
+      }
+
+      function spawnBubble() {
+        if (!isPlaying) return;
+        clearExistingBubble();
+
+        const bubble = document.createElement('button');
+        bubble.type = 'button';
+        bubble.className = 'bubble';
+        const size = randomBetween(68, 120);
+        const { width, height } = gameArea.getBoundingClientRect();
+        const maxLeft = Math.max(0, width - size);
+        const maxTop = Math.max(0, height - size);
+        const hue = Math.floor(Math.random() * 360);
+        bubble.style.setProperty('--hue', hue);
+        bubble.style.width = `${size}px`;
+        bubble.style.height = `${size}px`;
+        bubble.style.left = `${randomBetween(0, maxLeft)}px`;
+        bubble.style.top = `${randomBetween(0, maxTop)}px`;
+
+        bubble.addEventListener('click', () => handleBubbleHit(bubble));
+
+        gameArea.appendChild(bubble);
+        activeBubble = bubble;
+
+        const lifetime = Math.max(850, 1850 - score * 35);
+        bubbleTimeout = setTimeout(() => {
+          if (!isPlaying) return;
+          bubble.classList.add('fade');
+          setTimeout(() => bubble.remove(), 260);
+          activeBubble = null;
+          bubbleTimeout = null;
+          spawnTimeout = setTimeout(spawnBubble, 140);
+        }, lifetime);
+      }
+
+      function handleBubbleHit(bubble) {
+        if (!isPlaying) return;
+        const now = performance.now();
+        if (now - lastHitTime < 1200) {
+          streak += 1;
+        } else {
+          streak = 1;
+        }
+        lastHitTime = now;
+
+        score += 1;
+        updateScore();
+        bubble.classList.add('pop');
+        bubble.disabled = true;
+        setTimeout(() => bubble.remove(), 160);
+        activeBubble = null;
+        clearTimeout(bubbleTimeout);
+        bubbleTimeout = null;
+
+        const speedUpMessage = streak >= 3
+          ? `🔥 ${streak} 连击！泡泡加速出现！`
+          : `太棒了！当前得分 ${score}`;
+        statusText.textContent = speedUpMessage;
+
+        clearTimeout(spawnTimeout);
+        const delay = Math.max(90, 220 - streak * 12);
+        spawnTimeout = setTimeout(spawnBubble, delay);
+      }
+
+      function clearExistingBubble() {
+        if (activeBubble) {
+          activeBubble.remove();
+          activeBubble = null;
+        }
+        if (bubbleTimeout) {
+          clearTimeout(bubbleTimeout);
+          bubbleTimeout = null;
+        }
+      }
+
+      function updateScore() {
+        scoreElement.textContent = score;
+      }
+
+      function updateTimerDisplay() {
+        timeElement.textContent = timeLeft;
+        timerBar.setAttribute('aria-valuenow', timeLeft);
+        const progress = timeLeft / GAME_DURATION;
+        timerFill.style.transform = `scaleX(${progress})`;
+      }
+
+      function randomBetween(min, max) {
+        return Math.random() * (max - min) + min;
+      }
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the page with a liquid glass themed layout and animated background
- add a bubble catching mini-game with timer, scoring, streak feedback, and local best record tracking
- implement responsive glassmorphism components and animated bubbles for a playful experience

## Testing
- not run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68c90c37cb74832d9084609e348674b2